### PR TITLE
Fix Syncer E2E test parts

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|docs/package-lock.json|cmd/kube-watchall/go.sum|docs/config.toml|docs/resources/_gen|docs/static|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-14T15:02:41Z",
+  "generated_at": "2023-10-02T09:21:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -110,7 +110,7 @@
         "hashed_secret": "4d55af37dbbb6a42088d917caa1ca25428ec42c9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 353,
+        "line_number": 345,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/Makefile
+++ b/Makefile
@@ -423,18 +423,23 @@ endif
 # 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
 
 kcp/bin/kcp:
-	bash ./bootstrap/install-kcp-with-plugins.sh
+	bash ./bootstrap/bootstrap-kubestellar.sh --deploy false
 
 .PHONY: e2e-test-kubestellar-syncer
 e2e-test-kubestellar-syncer: WORK_DIR ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 e2e-test-kubestellar-syncer: TEST_ARGS ?= 
 e2e-test-kubestellar-syncer: KIND_CLUSTER_NAME ?= e2e-kubestellar
-e2e-test-kubestellar-syncer: e2e-test-kubestellar-syncer-cleanup kcp/bin/kcp
+e2e-test-kubestellar-syncer: e2e-test-kubestellar-syncer-cleanup bin/kubestellar kcp/bin/kcp
 	export PATH=$(PWD)/kcp/bin:$$PATH && \
 	kcp start --root-directory=$(WORK_DIR)/.kcp > $(WORK_DIR)/.kcp/kcp.log 2>&1 & PID=$$! && echo "PID $$PID" && \
 	trap 'kill -TERM $$PID' TERM INT EXIT && \
 	while [ ! -f "$(WORK_DIR)/.kcp/admin.kubeconfig" ]; do sleep 1; echo "kcp is not ready. wait for 1s...";done && \
-	echo 'Starting test(s)' && \
+	echo 'kcp is ready. Wait for Workspace API to be ready' && \
+	export KUBECONFIG=$(WORK_DIR)/.kcp/admin.kubeconfig && \
+	while ! kubectl get workspaces &> /dev/null; do sleep 1; echo "Workspace API is not ready. wait for 1s...";done && \
+	echo 'Workspace API is ready. Setup root:compute workspace by kubestellar init' && \
+	./scripts/kubestellar init && \
+	echo 'Starting test(s). To add TEST_ARGS=-v option to Make command if displaying the detail logs' && \
 	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) \
 		$(GO_TEST) -race $(COUNT_ARG) ./test/e2e/kubestellar-syncer/... $(TEST_ARGS) \
 		--kcp-kubeconfig $(WORK_DIR)/.kcp/admin.kubeconfig --suites kubestellar-syncer \

--- a/test/e2e/framework/kubestellar_syncer.go
+++ b/test/e2e/framework/kubestellar_syncer.go
@@ -49,7 +49,7 @@ import (
 
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
-	"github.com/kcp-dev/contrib-tmc/test/e2e/framework"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	workloadcliplugin "github.com/kubestellar/kubestellar/pkg/cliplugins/kubestellar/syncer-gen"
@@ -123,8 +123,6 @@ type kubeStellarSyncerFixture struct {
 func (sf *kubeStellarSyncerFixture) CreateEdgeSyncTargetAndApplyToDownstream(t *testing.T) *appliedKubeStellarSyncerFixture {
 	t.Helper()
 
-	useDeployedSyncer := len(framework.TestConfig.PClusterKubeconfig()) > 0
-
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := sf.upstreamServer.RawConfig()
 	require.NoError(t, err)
@@ -132,20 +130,14 @@ func (sf *kubeStellarSyncerFixture) CreateEdgeSyncTargetAndApplyToDownstream(t *
 
 	var downstreamConfig *rest.Config
 	var downstreamKubeconfigPath string
-	syncerImage := framework.TestConfig.SyncerImage()
 
-	if useDeployedSyncer {
-		// Test code is not implemented yet
-		require.NotZero(t, len(syncerImage), "--syncer-image must be specified if testing with a deployed syncer")
-	} else {
-		// The syncer will target a logical cluster that is a child of the current workspace. A
-		// logical server provides as a lightweight approximation of a pcluster for tests that
-		// don't need to validate running workloads or interaction with kube controllers.
-		downstreamServer := framework.NewFakeWorkloadServer(t, sf.upstreamServer, sf.edgeSyncTargetPath, sf.edgeSyncTargetName)
-		downstreamConfig = downstreamServer.BaseConfig(t)
-		downstreamKubeconfigPath = downstreamServer.KubeconfigPath()
-		syncerImage = "not-a-valid-image"
-	}
+	// The syncer will target a logical cluster that is a child of the current workspace. A
+	// logical server provides as a lightweight approximation of a pcluster for tests that
+	// don't need to validate running workloads or interaction with kube controllers.
+	downstreamServer := framework.NewFakeWorkloadServer(t, sf.upstreamServer, sf.edgeSyncTargetPath, sf.edgeSyncTargetName)
+	downstreamConfig = downstreamServer.BaseConfig(t)
+	downstreamKubeconfigPath = downstreamServer.KubeconfigPath()
+	syncerImage := "not-a-valid-image"
 
 	// Modify root:compute so that Syncer can update deployment.status
 	modifyRootCompute(t, upstreamRawConfig)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

I fixed e2e test codes so that it works without errors on KS codes with the PR (https://github.com/kubestellar/kubestellar/pull/1070) applied. 
- Keep to use `github.com/kcp-dev/kcp/test/e2e/framework` instead of `github.com/kcp-dev/contrib-tmc/test/e2e/framework`
  -  `contrib-tmc/test/e2e/framework` is something different from the original one and Syncer E2E fails when creating a test workspace. To keep to use the original e2e framework, there is still an issue that the it does no longer support `framework.TestConfig.PClusterKubeconfig()` function nor `framework.TestConfig.SyncerImage()` function. Fortunately, the current E2E does not actually use them so can work with the original e2e framework by just removing the relevant codes using these functions.
- Fix Makefile
  - to setup root:compute workspace by `kubestellar init`
  - to use bootstrap-kubestellar.sh instead of install-kcp-with-plugins.sh for kcp installation
    - install-kcp-with-plugins.sh is no longer referred by any code so the issue [#971](https://github.com/kubestellar/kubestellar/issues/971) may be closed by removing install-kcp-with-plugins.sh.  

## Related issue(s)

Fixes https://github.com/kubestellar/kubestellar/pull/1070
